### PR TITLE
Use gitstatus in the vcs segment if it's available

### DIFF
--- a/segments/p10ks_vcs_async
+++ b/segments/p10ks_vcs_async
@@ -2,10 +2,37 @@
 
 autoload -Uz vcs_info
 
-p10ks_vcs_async ()
-{
-  vcs_info
-  printf '%b' "${VCS_WORKDIR_DIRTY},;;;${vcs_info_msg_0_}"
+p10ks_vcs_async() {
+  [[ -v GITSTATUS_DAEMON_PID ]] && gitstatus_query_dir && {
+    # Fast path: use vcs info provided by gitstatus.
+    echo -nE "$((VCS_STATUS_HAS_STAGED || VCS_STATUS_HAS_UNSTAGED)),;;;"
+
+    echo -nE "$VCS_STATUS_LOCAL_BRANCH"
+    [[ -n "$VCS_STATUS_ACTION" ]] && {
+      echo -nE "%F{${red}}| $VCS_STATUS_ACTION%f"
+    } || {
+      # If local and remote branch names differ, show "local → remote" instead of just "local".
+      [[ -z "$VCS_STATUS_REMOTE_BRANCH" ]] ||
+        [[ "$VCS_STATUS_LOCAL_BRANCH" == "$VCS_STATUS_REMOTE_BRANCH" ]] ||
+        echo -nE $' \u2192 '"$VCS_STATUS_REMOTE_BRANCH"
+      local icons=''
+      (( VCS_STATUS_HAS_STAGED != 1 )) || icons+='✚'
+      (( VCS_STATUS_HAS_UNSTAGED != 1 )) || icons+='●'
+      (( VCS_STATUS_HAS_UNTRACKED != 1 )) || icons+='◌'
+      echo -nE "${icons:+ $icons}"
+      (( VCS_STATUS_COMMITS_AHEAD <= 0 )) || echo -nE " +$VCS_STATUS_COMMITS_AHEAD"
+      (( VCS_STATUS_COMMITS_BEHIND <= 0 )) || echo -nE " -$VCS_STATUS_COMMITS_BEHIND"
+      (( VCS_STATUS_STASHES <= 0 )) || echo -nE " ⋄$VCS_STATUS_STASHES"
+    }
+  } || {
+    # If GITSTATUS_DAEMON_PID is set, we've ended up here because $PWD is not a git repo.
+    # In this case we can disable git backend in vcs_info and only look for hg and cvs.
+    [[ -v GITSTATUS_DAEMON_PID ]] &&
+      zstyle ':vcs_info:*' enable hg svn ||
+      zstyle ':vcs_info:*' enable git hg svn
+    vcs_info
+    printf '%b' "${VCS_WORKDIR_DIRTY},;;;${vcs_info_msg_0_}"
+  }
 }
 
 # HACK/TODO ex. from my personal shell
@@ -13,10 +40,7 @@ zstyle ':vcs_info:svn*:*' actionformats '%c%u %F{red}| %a%f'
 zstyle ':vcs_info:*' actionformats '%b %F{red}| %a%f'
 # TODO unicode
 zstyle ':vcs_info:hg*:*' branchformat ' %b'
-# TODO unicode
-zstyle ':vcs_info:git*:*' branchformat ' %b'
 zstyle ':vcs_info:*' check-for-changes true
-zstyle ':vcs_info:*' enable git hg svn
 zstyle ':vcs_info:svn*:*' formats %c%u
 zstyle ':vcs_info:*' formats %b%c%u%m
 zstyle ':vcs_info:hg*:*' get-bookmarks true
@@ -29,20 +53,14 @@ zstyle ':vcs_info:*' unstagedstr ' ●'
 
 # VCS_INFO HOOKS
 zstyle ':vcs_info:git*+set-message:*' hooks \
- vcs-detect-changes git-untracked git-aheadbehind git-stash git-remotebranch git-tagname
+  vcs-detect-changes git-untracked git-aheadbehind
 zstyle ':vcs_info:hg*+set-message:*' hooks \
- vcs-detect-changes hg-branchhead
+  vcs-detect-changes hg-branchhead
 zstyle ':vcs_info:svn*+set-message:*' hooks \
- vcs-detect-changes svn-detect-changes
+  vcs-detect-changes svn-detect-changes
 
 ### Generic hook functions
 function +vi-vcs-detect-changes() {
-  if [[ "${hook_com[vcs]}" == "hg" ]]; then
-    vcs_visual_identifier='VCS_HG_ICON'
-  elif [[ "${hook_com[vcs]}" == "svn" ]]; then
-    vcs_visual_identifier='VCS_SVN_ICON'
-  fi
-
   if [[ -n "${hook_com[staged]}" ]] || [[ -n "${hook_com[unstaged]}" ]]; then
     VCS_WORKDIR_DIRTY=1
   else
@@ -82,23 +100,6 @@ function +vi-git-aheadbehind() {
 
   hook_com[misc]+=${(j:/:)gitstatus}
 }
-
-# function +vi-git-remotebranch() {
-#   local remote
-#
-#   # Are we on a remote-tracking branch?
-#   remote=${$(git rev-parse --verify ${hook_com[branch]}@{upstream} \
-#     --symbolic-full-name 2>/dev/null)/refs\/remotes\/}
-#
-#   # The first test will show a tracking branch whenever there is one. The
-#   # second test, however, will only show the remote branch's name if it
-#   # differs from the local one.
-#   if [[ -n ${remote} ]] ; then
-#   #if [[ -n ${remote} && ${remote#*/} != ${hook_com[branch]} ]] ; then
-#     # TODO unicode
-#     hook_com[branch]=" ${hook_com[branch]} [${remote}]"
-#   fi
-# }
 
 ### HG hook functions
 

--- a/segments/p10ks_vcs_async
+++ b/segments/p10ks_vcs_async
@@ -2,8 +2,18 @@
 
 autoload -Uz vcs_info
 
+[[ "${(t)p10ks_vcs}" != "association" ]] && {
+  typeset -gA p10ks_vcs
+}
+
+# env-vars {{{
+# p10ks_vcs[backends] -> space-separated list of vcs backends; supports 'git', 'svn' and 'hg'
+: ${p10ks_vcs[backends]=git svn hg}
+# }}}
+
 p10ks_vcs_async() {
-  [[ -v GITSTATUS_DAEMON_PID ]] && gitstatus_query_dir && {
+  local -a backends=(${(z)p10ks_vcs[backends]})
+  (( ${backends[(I)git]} )) && [[ -v GITSTATUS_DAEMON_PID ]] && gitstatus_query_dir && {
     # Fast path: use vcs info provided by gitstatus.
     echo -nE "$((VCS_STATUS_HAS_STAGED || VCS_STATUS_HAS_UNSTAGED)),;;;"
     echo -nE "$VCS_STATUS_LOCAL_BRANCH"
@@ -30,13 +40,13 @@ p10ks_vcs_async() {
       # untracked files. We are 1 commit ahead and 2 commits behind. We have 3 stashes.
     }
   } || {
-    # If GITSTATUS_DAEMON_PID is set, we've ended up here because $PWD is not a git repo.
-    # In this case we can disable git backend in vcs_info and only look for hg and cvs.
-    [[ -v GITSTATUS_DAEMON_PID ]] &&
-      zstyle ':vcs_info:*' enable hg svn ||
-      zstyle ':vcs_info:*' enable git hg svn
-    vcs_info
-    printf '%b' "${VCS_WORKDIR_DIRTY},;;;${vcs_info_msg_0_}"
+    # Remove git from the list of backends if we know we aren't in a git repo.
+    [[ ! -v GITSTATUS_DAEMON_PID ]] || backends=(${backends:#git})
+    (( ! backends )) || {
+      zstyle ':vcs_info:*' enable ${backends}
+      vcs_info
+      printf '%b' "${VCS_WORKDIR_DIRTY},;;;${vcs_info_msg_0_}"
+    }
   }
 }
 

--- a/segments/p10ks_vcs_async
+++ b/segments/p10ks_vcs_async
@@ -42,7 +42,7 @@ p10ks_vcs_async() {
   } || {
     # Remove git from the list of backends if we know we aren't in a git repo.
     [[ ! -v GITSTATUS_DAEMON_PID ]] || backends=(${backends:#git})
-    (( ! backends )) || {
+    (( ! #backends )) || {
       zstyle ':vcs_info:*' enable ${backends}
       vcs_info
       printf '%b' "${VCS_WORKDIR_DIRTY},;;;${vcs_info_msg_0_}"

--- a/segments/p10ks_vcs_async
+++ b/segments/p10ks_vcs_async
@@ -6,23 +6,28 @@ p10ks_vcs_async() {
   [[ -v GITSTATUS_DAEMON_PID ]] && gitstatus_query_dir && {
     # Fast path: use vcs info provided by gitstatus.
     echo -nE "$((VCS_STATUS_HAS_STAGED || VCS_STATUS_HAS_UNSTAGED)),;;;"
-
     echo -nE "$VCS_STATUS_LOCAL_BRANCH"
     [[ -n "$VCS_STATUS_ACTION" ]] && {
       echo -nE "%F{${red}}| $VCS_STATUS_ACTION%f"
     } || {
-      # If local and remote branch names differ, show "local → remote" instead of just "local".
+      # If local and remote branch names differ, show "local→remote" instead of just "local".
       [[ -z "$VCS_STATUS_REMOTE_BRANCH" ]] ||
         [[ "$VCS_STATUS_LOCAL_BRANCH" == "$VCS_STATUS_REMOTE_BRANCH" ]] ||
-        echo -nE $' \u2192 '"$VCS_STATUS_REMOTE_BRANCH"
+        echo -nE $'\u2192'"$VCS_STATUS_REMOTE_BRANCH"
       local icons=''
-      (( VCS_STATUS_HAS_STAGED != 1 )) || icons+='✚'
-      (( VCS_STATUS_HAS_UNSTAGED != 1 )) || icons+='●'
-      (( VCS_STATUS_HAS_UNTRACKED != 1 )) || icons+='◌'
+      (( VCS_STATUS_HAS_STAGED != 1 )) || icons+=$'\u271a'    # ✚
+      (( VCS_STATUS_HAS_UNSTAGED != 1 )) || icons+=$'\u25cf'  # ●
+      (( VCS_STATUS_HAS_UNTRACKED != 1 )) || icons+=$'\u25cc' # ◌
       echo -nE "${icons:+ $icons}"
       (( VCS_STATUS_COMMITS_AHEAD <= 0 )) || echo -nE " +$VCS_STATUS_COMMITS_AHEAD"
       (( VCS_STATUS_COMMITS_BEHIND <= 0 )) || echo -nE " -$VCS_STATUS_COMMITS_BEHIND"
-      (( VCS_STATUS_STASHES <= 0 )) || echo -nE " ⋄$VCS_STATUS_STASHES"
+      (( VCS_STATUS_STASHES <= 0 )) || echo -nE $' \u22c4'"$VCS_STATUS_STASHES"
+      # Prompt example with all optional parts present:
+      #
+      #   feature→master ✚●◌ +1 -2 ⋄3
+      #
+      # We are on branch "feature" that tracks "origin/master". We have staged, unstaged and
+      # untracked files. We are 1 commit ahead and 2 commits behind. We have 3 stashes.
     }
   } || {
     # If GITSTATUS_DAEMON_PID is set, we've ended up here because $PWD is not a git repo.
@@ -38,18 +43,15 @@ p10ks_vcs_async() {
 # HACK/TODO ex. from my personal shell
 zstyle ':vcs_info:svn*:*' actionformats '%c%u %F{red}| %a%f'
 zstyle ':vcs_info:*' actionformats '%b %F{red}| %a%f'
-# TODO unicode
-zstyle ':vcs_info:hg*:*' branchformat ' %b'
+zstyle ':vcs_info:hg*:*' branchformat '%b'
 zstyle ':vcs_info:*' check-for-changes true
 zstyle ':vcs_info:svn*:*' formats %c%u
 zstyle ':vcs_info:*' formats %b%c%u%m
 zstyle ':vcs_info:hg*:*' get-bookmarks true
 zstyle ':vcs_info:hg*:*' get-revision true
 zstyle ':vcs_info:hg*+gen-hg-bookmark-string:*' hooks hg-bookmarks
-# TODO unicode
-zstyle ':vcs_info:*' stagedstr ' ✚'
-# TODO unicode
-zstyle ':vcs_info:*' unstagedstr ' ●'
+zstyle ':vcs_info:*' stagedstr $' \u271a'   # ✚
+zstyle ':vcs_info:*' unstagedstr $' \u25cf' # ●
 
 # VCS_INFO HOOKS
 zstyle ':vcs_info:git*+set-message:*' hooks \
@@ -77,8 +79,7 @@ function +vi-git-untracked(){
     # If instead you want to show the marker only if there are untracked
     # files in $PWD, use:
     #[[ -n $(git ls-files --others --exclude-standard) ]] ; then
-    # TODO unicode
-    hook_com[unstaged]+='◌'
+    hook_com[unstaged]+=$'\u25cc' # '◌'
   fi
 }
 
@@ -89,23 +90,17 @@ function +vi-git-aheadbehind() {
   # for git prior to 1.7
   # ahead=$(git rev-list origin/${hook_com[branch]}..HEAD | wc -l)
   ahead=$(git rev-list ${hook_com[branch]}@{upstream}..HEAD 2>/dev/null | wc -l)
-  # TODO unicode
   (( $ahead )) && gitstatus+=( " +${ahead}" )
 
   # for git prior to 1.7
   # behind=$(git rev-list HEAD..origin/${hook_com[branch]} | wc -l)
   behind=$(git rev-list HEAD..${hook_com[branch]}@{upstream} 2>/dev/null | wc -l)
-  # TODO unicode
   (( $behind )) && gitstatus+=( " -${behind}" )
 
   hook_com[misc]+=${(j:/:)gitstatus}
 }
 
 ### HG hook functions
-
-function +vi-hg-storerev() {
-  user_data[hash]=${hook_com[hash]}
-}
 
 function +vi-hg-branchhead() {
   local branchheadsfile i_tiphash i_branchname

--- a/zsdoc-src/p10ks_vcs
+++ b/zsdoc-src/p10ks_vcs
@@ -75,8 +75,18 @@ p10ks_vcs_bg "$@"
 
 autoload -Uz vcs_info
 
+[[ "${(t)p10ks_vcs}" != "association" ]] && {
+  typeset -gA p10ks_vcs
+}
+
+# env-vars {{{
+# p10ks_vcs[backends] -> space-separated list of vcs backends; supports 'git', 'svn' and 'hg'
+: ${p10ks_vcs[backends]=git svn hg}
+# }}}
+
 p10ks_vcs_async() {
-  [[ -v GITSTATUS_DAEMON_PID ]] && gitstatus_query_dir && {
+  local -a backends=(${(z)p10ks_vcs[backends]})
+  (( ${backends[(I)git]} )) && [[ -v GITSTATUS_DAEMON_PID ]] && gitstatus_query_dir && {
     # Fast path: use vcs info provided by gitstatus.
     echo -nE "$((VCS_STATUS_HAS_STAGED || VCS_STATUS_HAS_UNSTAGED)),;;;"
     echo -nE "$VCS_STATUS_LOCAL_BRANCH"
@@ -103,13 +113,13 @@ p10ks_vcs_async() {
       # untracked files. We are 1 commit ahead and 2 commits behind. We have 3 stashes.
     }
   } || {
-    # If GITSTATUS_DAEMON_PID is set, we've ended up here because $PWD is not a git repo.
-    # In this case we can disable git backend in vcs_info and only look for hg and cvs.
-    [[ -v GITSTATUS_DAEMON_PID ]] &&
-      zstyle ':vcs_info:*' enable hg svn ||
-      zstyle ':vcs_info:*' enable git hg svn
-    vcs_info
-    printf '%b' "${VCS_WORKDIR_DIRTY},;;;${vcs_info_msg_0_}"
+    # Remove git from the list of backends if we know we aren't in a git repo.
+    [[ ! -v GITSTATUS_DAEMON_PID ]] || backends=(${backends:#git})
+    (( ! backends )) || {
+      zstyle ':vcs_info:*' enable ${backends}
+      vcs_info
+      printf '%b' "${VCS_WORKDIR_DIRTY},;;;${vcs_info_msg_0_}"
+    }
   }
 }
 

--- a/zsdoc-src/p10ks_vcs
+++ b/zsdoc-src/p10ks_vcs
@@ -75,44 +75,64 @@ p10ks_vcs_bg "$@"
 
 autoload -Uz vcs_info
 
-p10ks_vcs_async ()
-{
-  vcs_info
-  printf '%b' "${VCS_WORKDIR_DIRTY},;;;${vcs_info_msg_0_}"
+p10ks_vcs_async() {
+  [[ -v GITSTATUS_DAEMON_PID ]] && gitstatus_query_dir && {
+    # Fast path: use vcs info provided by gitstatus.
+    echo -nE "$((VCS_STATUS_HAS_STAGED || VCS_STATUS_HAS_UNSTAGED)),;;;"
+    echo -nE "$VCS_STATUS_LOCAL_BRANCH"
+    [[ -n "$VCS_STATUS_ACTION" ]] && {
+      echo -nE "%F{${red}}| $VCS_STATUS_ACTION%f"
+    } || {
+      # If local and remote branch names differ, show "local→remote" instead of just "local".
+      [[ -z "$VCS_STATUS_REMOTE_BRANCH" ]] ||
+        [[ "$VCS_STATUS_LOCAL_BRANCH" == "$VCS_STATUS_REMOTE_BRANCH" ]] ||
+        echo -nE $'→'"$VCS_STATUS_REMOTE_BRANCH"
+      local icons=''
+      (( VCS_STATUS_HAS_STAGED != 1 )) || icons+=$'✚'    # ✚
+      (( VCS_STATUS_HAS_UNSTAGED != 1 )) || icons+=$'●'  # ●
+      (( VCS_STATUS_HAS_UNTRACKED != 1 )) || icons+=$'◌' # ◌
+      echo -nE "${icons:+ $icons}"
+      (( VCS_STATUS_COMMITS_AHEAD <= 0 )) || echo -nE " +$VCS_STATUS_COMMITS_AHEAD"
+      (( VCS_STATUS_COMMITS_BEHIND <= 0 )) || echo -nE " -$VCS_STATUS_COMMITS_BEHIND"
+      (( VCS_STATUS_STASHES <= 0 )) || echo -nE $' ⋄'"$VCS_STATUS_STASHES"
+      # Prompt example with all optional parts present:
+      #
+      #   feature→master ✚●◌ +1 -2 ⋄3
+      #
+      # We are on branch "feature" that tracks "origin/master". We have staged, unstaged and
+      # untracked files. We are 1 commit ahead and 2 commits behind. We have 3 stashes.
+    }
+  } || {
+    # If GITSTATUS_DAEMON_PID is set, we've ended up here because $PWD is not a git repo.
+    # In this case we can disable git backend in vcs_info and only look for hg and cvs.
+    [[ -v GITSTATUS_DAEMON_PID ]] &&
+      zstyle ':vcs_info:*' enable hg svn ||
+      zstyle ':vcs_info:*' enable git hg svn
+    vcs_info
+    printf '%b' "${VCS_WORKDIR_DIRTY},;;;${vcs_info_msg_0_}"
+  }
 }
 
 # HACK/TODO ex. from my personal shell
 zstyle ':vcs_info:svn*:*' actionformats '%c%u %F{red}| %a%f'
 zstyle ':vcs_info:*' actionformats '%b %F{red}| %a%f'
-# TODO unicode
-zstyle ':vcs_info:hg*:*' branchformat ' %b'
-# TODO unicode
-zstyle ':vcs_info:git*:*' branchformat ' %b'
+zstyle ':vcs_info:hg*:*' branchformat '%b'
 zstyle ':vcs_info:*' check-for-changes true
-zstyle ':vcs_info:*' enable git hg svn
 zstyle ':vcs_info:svn*:*' formats %c%u
 zstyle ':vcs_info:*' formats %b%c%u%m
 zstyle ':vcs_info:hg*:*' get-bookmarks true
 zstyle ':vcs_info:hg*:*' get-revision true
 zstyle ':vcs_info:hg*+gen-hg-bookmark-string:*' hooks hg-bookmarks
-# TODO unicode
-zstyle ':vcs_info:*' stagedstr ' ✚'
-# TODO unicode
-zstyle ':vcs_info:*' unstagedstr ' ●'
+zstyle ':vcs_info:*' stagedstr $' ✚'   # ✚
+zstyle ':vcs_info:*' unstagedstr $' ●' # ●
 
 # VCS_INFO HOOKS
-zstyle ':vcs_info:git*+set-message:*' hooks \n vcs-detect-changes git-untracked git-aheadbehind git-stash git-remotebranch git-tagname
-zstyle ':vcs_info:hg*+set-message:*' hooks \n vcs-detect-changes hg-branchhead
-zstyle ':vcs_info:svn*+set-message:*' hooks \n vcs-detect-changes svn-detect-changes
+zstyle ':vcs_info:git*+set-message:*' hooks \n  vcs-detect-changes git-untracked git-aheadbehind
+zstyle ':vcs_info:hg*+set-message:*' hooks \n  vcs-detect-changes hg-branchhead
+zstyle ':vcs_info:svn*+set-message:*' hooks \n  vcs-detect-changes svn-detect-changes
 
 ### Generic hook functions
 function +vi-vcs-detect-changes() {
-  if [[ "${hook_com[vcs]}" == "hg" ]]; then
-    vcs_visual_identifier='VCS_HG_ICON'
-  elif [[ "${hook_com[vcs]}" == "svn" ]]; then
-    vcs_visual_identifier='VCS_SVN_ICON'
-  fi
-
   if [[ -n "${hook_com[staged]}" ]] || [[ -n "${hook_com[unstaged]}" ]]; then
     VCS_WORKDIR_DIRTY=1
   else
@@ -128,8 +148,7 @@ function +vi-git-untracked(){
     # If instead you want to show the marker only if there are untracked
     # files in $PWD, use:
     #[[ -n $(git ls-files --others --exclude-standard) ]] ; then
-    # TODO unicode
-    hook_com[unstaged]+='◌'
+    hook_com[unstaged]+=$'◌' # '◌'
   fi
 }
 
@@ -140,39 +159,17 @@ function +vi-git-aheadbehind() {
   # for git prior to 1.7
   # ahead=$(git rev-list origin/${hook_com[branch]}..HEAD | wc -l)
   ahead=$(git rev-list ${hook_com[branch]}@{upstream}..HEAD 2>/dev/null | wc -l)
-  # TODO unicode
   (( $ahead )) && gitstatus+=( " +${ahead}" )
 
   # for git prior to 1.7
   # behind=$(git rev-list HEAD..origin/${hook_com[branch]} | wc -l)
   behind=$(git rev-list HEAD..${hook_com[branch]}@{upstream} 2>/dev/null | wc -l)
-  # TODO unicode
   (( $behind )) && gitstatus+=( " -${behind}" )
 
   hook_com[misc]+=${(j:/:)gitstatus}
 }
 
-# function +vi-git-remotebranch() {
-#   local remote
-#
-#   # Are we on a remote-tracking branch?
-#   remote=${$(git rev-parse --verify ${hook_com[branch]}@{upstream} \n#     --symbolic-full-name 2>/dev/null)/refs/remotes/}
-#
-#   # The first test will show a tracking branch whenever there is one. The
-#   # second test, however, will only show the remote branch's name if it
-#   # differs from the local one.
-#   if [[ -n ${remote} ]] ; then
-#   #if [[ -n ${remote} && ${remote#*/} != ${hook_com[branch]} ]] ; then
-#     # TODO unicode
-#     hook_com[branch]=" ${hook_com[branch]} [${remote}]"
-#   fi
-# }
-
 ### HG hook functions
-
-function +vi-hg-storerev() {
-  user_data[hash]=${hook_com[hash]}
-}
 
 function +vi-hg-branchhead() {
   local branchheadsfile i_tiphash i_branchname

--- a/zsdoc/p10ks_vcs.adoc
+++ b/zsdoc/p10ks_vcs.adoc
@@ -36,6 +36,7 @@ ENVIRONMENT VARIABLES
 [width="80%",cols="4,10"]
 |======
 |p10ks_battery[color_loading]|bgcolor while async process is running
+|p10ks_vcs[backends]|space-separated list of vcs backends; supports 'git', 'svn' and 'hg'
 |p10ks_vcs[color_default]|color when repo is clean
 |p10ks_vcs[color_dirty]|bgcolor when repo is dirty
 |p10ks_vcs[loading_msg]|message while waiting for async process
@@ -48,7 +49,7 @@ DETAILS
 Script Body
 ~~~~~~~~~~~
 
-Has 41 line(s). Calls functions:
+Has 46 line(s). Calls functions:
 
  Script-Body
  |-- p10ks_vcs
@@ -76,7 +77,11 @@ Called by:
 p10ks_vcs_async
 ~~~~~~~~~~~~~~~
 
-Has 25 line(s). Calls functions:
+____
+ # }}}
+____
+
+Has 27 line(s). Calls functions:
 
  p10ks_vcs_async
  `-- vcs_info

--- a/zsdoc/p10ks_vcs.adoc
+++ b/zsdoc/p10ks_vcs.adoc
@@ -28,7 +28,6 @@ FUNCTIONS
  +vi-git-aheadbehind
  +vi-git-untracked
  +vi-hg-branchhead
- +vi-hg-storerev
  +vi-vcs-detect-changes
 AUTOLOAD vcs_info
 
@@ -49,7 +48,7 @@ DETAILS
 Script Body
 ~~~~~~~~~~~
 
-Has 43 line(s). Calls functions:
+Has 41 line(s). Calls functions:
 
  Script-Body
  |-- p10ks_vcs
@@ -77,10 +76,12 @@ Called by:
 p10ks_vcs_async
 ~~~~~~~~~~~~~~~
 
-Has 2 line(s). Calls functions:
+Has 25 line(s). Calls functions:
 
  p10ks_vcs_async
  `-- vcs_info
+
+Uses feature(s): _zstyle_
 
 Called by:
 
@@ -159,20 +160,13 @@ Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 +vi-hg-branchhead
 ~~~~~~~~~~~~~~~~~
 
-Has 15 line(s). Doesn't call other functions.
-
-Uses feature(s): _read_
-
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
-
-+vi-hg-storerev
-~~~~~~~~~~~~~~~
-
 ____
  ### HG hook functions
 ____
 
-Has 1 line(s). Doesn't call other functions.
+Has 15 line(s). Doesn't call other functions.
+
+Uses feature(s): _read_
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -183,7 +177,7 @@ ____
  ### Generic hook functions
 ____
 
-Has 11 line(s). Doesn't call other functions.
+Has 5 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 


### PR DESCRIPTION
This is an alternative to https://github.com/robobenklein/p10k/pull/1 based on your suggestions. It modifies the existing vcs segment to do the following:

```
if (gitstatus is available) {
  if (git repo) {
    use gitstatus
  } else {
    use vc_info with hg and svn backends enabled (without git)
  }
} else {
  use vc_info with git, hg and svn backends enabled
}
```

Because `p10ks_vcs_async` runs in a fork, gitstatus must be sourced before p10k. Basically, the process where `p10ks_vcs_async` runs must have environment variables that gitstatus plugin sets when it's loading. This is brittle and will certainly trip users. I don't know how to fix this.

The generated prompt isn't exactly identical to what `vcs_info` produces. `vcs_info` uses spaces before and between icons inconsistently. Take a look:

```zsh
> master◌
> master ✚
> master ✚◌ 
> master ✚◌
> master ✚ ●◌
```

The first and the last prompt look weird. With gitstatus it's consistent:

```zsh
> master ◌
> master ✚
> master ✚◌ 
> master ✚◌
> master ✚●◌
```

It's possible that I'm missing the intent of the apparent missing and extra spaces `vcs_info` generates. Let me know if so.

Another difference is that gitstatus prints remote branch name if it's present and is different from local. I personally find it useful. In most cases it doesn't use up space because there is usually either no remote branch or it's the same as local.

And lastly, gitstatus shows the number of stashes. For people who don't use stashes there will be no wasted space. For those who do, they'll appreciate the info.

These extra pieces of info come at no performance cost.

Here's an example (also in the comments):

```
feature→master ✚●◌ +1 -2 ⋄3
```

We are on branch "feature" that tracks "origin/master". We have staged, unstaged and untracked files. We are 1 commit ahead and 2 commits behind. We have 3 stashes.

I also cleaned up the existing code. I hope you don't mind.

To test on Docker:

```zsh
docker run -e LANG=C.UTF-8 -e LC_ALL=C.UTF-8 -e TERM=$TERM -it --rm ubuntu bash -c '
  set -uex
  apt update
  apt install -y zsh git
  cd
  git clone https://github.com/romkatv/gitstatus.git
  git clone -b gitstatus2 https://github.com/romkatv/p10k
  echo "
    source ~/gitstatus/gitstatus.plugin.zsh
    source ~/p10k/presets/robobenklein.p10kp.zsh
    source ~/p10k/p10k.zsh" >~/.zshrc
  cd p10k
  zsh -i'
```

Remove `source ~/gitstatus/gitstatus.plugin.zsh` to check how it works when gitstatus isn't available.

Note that prompt is fast only in git repos (about 3 times faster than before). In directories that aren't repos at all (e.g., the root dir), the prompt is still slow because it calls `vcs_info`. Even though I disable git backend on this call, it doesn't help much. Many people don't care about non-git repos (myself included), so they shouldn't have to suffer. To solve this problem, I made vcs backends configurable. Everything will be fast if you add the following stanza to `presets/robobenklein.p10kp.zsh`:

```
typeset -gA p10ks_vcs
p10ks_vcs[backends]=git
```

P.S.

I haven't tested it with svn or hg. Please do test if you intend to merge this PR.